### PR TITLE
Podspec update for 1.1.2 version

### DIFF
--- a/Sovran.podspec
+++ b/Sovran.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage         = 'https://github.com/customerio/Sovran-Swift'
   s.license          = { :type => 'MIT', :file => './LICENSE' }
   s.authors          = "Segment, Inc."
-  s.source           = { :git => 'https://github.com/segmentio/Sovran-Swift', :branch => 'main' }
+  s.source           = { :git => 'https://github.com/segmentio/Sovran-Swift.git', :tag => '1.1.2' }
   s.ios.deployment_target = '13.0'
   s.swift_version = '5.3'
   s.source_files = 'Sources/**/*'

--- a/Sovran.podspec
+++ b/Sovran.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name             = 'Sovran'
   s.module_name      = 'Sovran'
-  s.version          = '1.1.1'
+  s.version          = '1.1.2'
   s.summary          = 'Sovran-Swift Cocoapods support.'
   s.homepage         = 'https://github.com/customerio/Sovran-Swift'
   s.license          = { :type => 'MIT', :file => './LICENSE' }
   s.authors          = "Segment, Inc."
-  s.source           = { :git => 'https://github.com/customerio/Sovran-Swift.git', :branch => 'main' }
-  s.ios.deployment_target = '11.0'
-  s.swift_version = '5.0'
+  s.source           = { :git => 'https://github.com/segmentio/Sovran-Swift', :branch => 'main' }
+  s.ios.deployment_target = '13.0'
+  s.swift_version = '5.3'
   s.source_files = 'Sources/**/*'
 end


### PR DESCRIPTION
The following things have been updated:
- `version `: to latest 1.1.2 from upstream
- `source `: since we didn't make any code changes and tag 1.1.2 only exists in the upstream repo, it makes more sense to point directly. This will prevent the future need to merge upstream to our fork.
- `ios.deployment_target `: synced with Package.swift
- `swift_version `: synced with Package.swift