### PR TITLE
DX-516: Pin actions to SHA

### DIFF
--- a/.github/workflows/create_jira.yml
+++ b/.github/workflows/create_jira.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
     - name: Login
-      uses: atlassian/gajira-login@master
+      uses: atlassian/gajira-login@c22a5debd482401472b285de4f6deedf70ddbb92 # master
       env:
         JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
         JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -24,7 +24,7 @@ jobs:
 
     - name: Create
       id: create
-      uses: atlassian/gajira-create@master
+      uses: atlassian/gajira-create@1c54357fdde9dab6273a0e26d67cb175ffffe498 # master
       with:
         project: ${{ secrets.JIRA_PROJECT }}
         issuetype: Bug

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -10,7 +10,7 @@ jobs:
   cancel_previous:
     runs-on: ubuntu-latest
     steps:
-    - uses: styfle/cancel-workflow-action@0.9.1
+    - uses: styfle/cancel-workflow-action@a40b8845c0683271d9f53dfcb887a7e181d3918b # 0.9.1
       with:
         workflow_id: ${{ github.event.workflow.id }}
         
@@ -18,7 +18,7 @@ jobs:
     needs: cancel_previous
     runs-on: macos-latest
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
+    - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: latest-stable
     - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
     needs: cancel_previous
     runs-on: ubuntu-latest
     steps:
-    - uses: fwal/setup-swift@v1.21.0
+    - uses: fwal/setup-swift@bc791cf26355e933efee44da402ca4c8887fca3a # v1.21.0
       with:
         swift-version: "5.7.2"
     - uses: actions/checkout@v2
@@ -44,7 +44,7 @@ jobs:
     needs: cancel_previous
     runs-on: macos-latest
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
+    - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: latest-stable
     - uses: actions/checkout@v2
@@ -60,7 +60,7 @@ jobs:
     needs: cancel_previous
     runs-on: macos-latest
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
+    - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: latest-stable
     - uses: actions/checkout@v2
@@ -76,7 +76,7 @@ jobs:
     needs: cancel_previous
     runs-on: macos-latest
     steps:
-    - uses: maxim-lobanov/setup-xcode@v1
+    - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
       with:
         xcode-version: latest-stable
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR pins GitHub Actions to SHA hashes instead of tags.